### PR TITLE
Mount working folder as relative path in /data and respect gitignore.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "b2d-sync",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "continous syncing of host folder to boot2docker VM via rsync",
   "main": "watch.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 ## b2d-sync
 
-This will keep a given folder in sync with a folder under the same path inside boot2docker VM. 
+This will keep a given folder in sync with `/data` inside boot2docker VM.  It respects
+basic .gitignore filtering using `rsync --exclude-from=.gitignore`.
 
 ### install:
 
@@ -10,4 +11,3 @@ This will keep a given folder in sync with a folder under the same path inside b
 
     cd <working dir>
     bdsync
-

--- a/watch.js
+++ b/watch.js
@@ -1,8 +1,11 @@
 var async = require('async');
 var chokidar = require('chokidar');
 var cp = require('child_process');
+var path = require('path');
 
 var docker_ip;
+
+var hostPath = '/data';
 
 function getdockerip (cb) {
   cp.exec('boot2docker ip 2>/dev/null', function (err, stdout) {
@@ -22,9 +25,11 @@ function install_rsync (cb) {
 
 function rsync (cb) {
   var child = cp.spawn('rsync', [
-    '-av',
+    '-av', 
      process.cwd() + '/',
-     'docker@' + docker_ip + ':' + process.cwd()
+     '--exclude-from',
+     '.gitignore',
+     'docker@' + docker_ip + ':' + hostPath
   ]);
   child.stderr.on('data', function (data) { 
     console.error(data.toString());
@@ -38,7 +43,7 @@ function rsync (cb) {
 }
 
 function mkdirp (cb) {
-  cp.exec('boot2docker ssh "sudo mkdir -p ' + process.cwd() + ' && sudo chown docker ' + process.cwd() + '"', function() {
+  cp.exec('boot2docker ssh "sudo mkdir -p ' + hostPath + ' && sudo chown docker ' + hostPath + '"', function() {
     cb();
   });
 }


### PR DESCRIPTION
I modified bdsync to sync into `/data` folder of host, using relative paths not full `pwd`.  I also added `--exclude-from=.gitignore`.  You do need to add .git to your .gitignore, so there's not 1-1 compatibility. but it works pretty well.  This does prevent things like `node_modules` from overwriting with wrong binaries.
