### PR TITLE
Allow to configure targetPath and ignoreFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "b2d-sync",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "continous syncing of host folder to boot2docker VM via rsync",
   "main": "watch.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/jkingyens/b2d-sync",
   "dependencies": {
     "async": "^0.9.0",
-    "chokidar": "^0.8.4",
+    "chokidar": "^0.12.6",
     "nconf": "^0.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/jkingyens/b2d-sync",
   "dependencies": {
     "async": "^0.9.0",
-    "chokidar": "^0.8.4"
+    "chokidar": "^0.8.4",
+    "nconf": "^0.7.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## b2d-sync
 
-This will keep a given folder in sync with a folder under the same path inside boot2docker VM. 
+This will keep a given folder in sync with a folder inside boot2docker VM. Per default the current folder will be synced to boot2docker VM (see configuration).
 
 ### install:
 
@@ -10,4 +10,20 @@ This will keep a given folder in sync with a folder under the same path inside b
 
     cd <working dir>
     bdsync
+
+### configuration
+
+The following config options can be set either as environment variable, as command line argument or in the config file b2dsync.json:
+
+    targetPath: Path in the boot2docker VM (will be automatically created)
+    ignoreFile: File from which rsync ignores should be taken (per default .gitignore)
+
+Example for command line:
+
+    bdsync --targetPath=/mnt/test
+
+Example for config file:
+
+    bdsync.json
+    {"targetPath" : "/mnt/test"}
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ This will keep a given folder in sync with a folder inside boot2docker VM. Per d
 
 ### configuration:
 
-The following config options can be set either as environment variable, as command line argument or in the config file b2dsync.json:
+The following config options can be set either as environment variable, as command line argument or in the config file bdsync.json:
 
     targetPath: Path in the boot2docker VM (will be automatically created)
     ignoreFile: File from which rsync ignores should be taken (per default .gitignore)

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ This will keep a given folder in sync with a folder inside boot2docker VM. Per d
     cd <working dir>
     bdsync
 
-### configuration
+### configuration:
 
 The following config options can be set either as environment variable, as command line argument or in the config file b2dsync.json:
 
@@ -22,8 +22,7 @@ Example for command line:
 
     bdsync --targetPath=/mnt/test
 
-Example for config file:
+Example for config file bdsync.json:
 
-    bdsync.json
     {"targetPath" : "/mnt/test"}
 

--- a/samples/.syncignore
+++ b/samples/.syncignore
@@ -1,0 +1,1 @@
+readme.md

--- a/samples/bdsync.json
+++ b/samples/bdsync.json
@@ -1,0 +1,4 @@
+{
+  "targetPath" : "/mnt/sda1/var/test",
+  "ignoreFile" : ".syncignore"
+}

--- a/watch.js
+++ b/watch.js
@@ -30,6 +30,7 @@ function install_rsync (cb) {
 function rsync (cb) {
   var child = cp.spawn('rsync', [
     '-av',
+    '--delete',
      process.cwd() + '/',
      '--exclude-from',
      nconf.get('ignoreFile'),


### PR DESCRIPTION
Really like b2d-sync. For our use case it would be great to allow configuration of target path in boot2docker VM and allow to define an ignore file for rsync. The changes should be full backwards compatible.