### PR TITLE
Use existing boot2docker ssh key ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "b2d-sync",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "continous syncing of host folder to boot2docker VM via rsync",
   "main": "watch.js",
   "scripts": {
@@ -22,6 +22,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "chokidar": "^0.12.6",
-    "nconf": "^0.7.1"
+    "nconf": "^0.7.1",
+    "osenv": "^0.1.0"
   }
 }

--- a/watch.js
+++ b/watch.js
@@ -1,5 +1,6 @@
 var async = require('async');
 var chokidar = require('chokidar');
+var osenv = require('osenv');
 var cp = require('child_process');
 var nconf = require('nconf');
 var docker_ip;
@@ -30,6 +31,7 @@ function install_rsync (cb) {
 function rsync (cb) {
   var child = cp.spawn('rsync', [
     '-av',
+    '--rsh=ssh -i ' + osenv.home() + '/.ssh/id_boot2docker -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no',
     '--delete',
      process.cwd() + '/',
      '--exclude-from',


### PR DESCRIPTION
...  and avoid issues with known_hosts when upgrading boot2docker

Resolves #4 