### PR TITLE
Watch for new/deleted file events

### DIFF
--- a/watch.js
+++ b/watch.js
@@ -64,8 +64,8 @@ async.series([
   install_rsync,
   rsync
 ], function (err) {
-  var watcher = chokidar.watch(process.cwd(), { persistent: true });
-  watcher.on('change', function () {
+  var watcher = chokidar.watch(process.cwd(), { persistent: true, ignoreInitial: true });
+  watcher.on('all', function () {
     rsync(function (cb) {
       console.log('refreshing');
     });


### PR DESCRIPTION
Thanks for making b2d-sync. It's really slick & useful.

Previously, creating a new file (`touch foo`) or deleting a file did
not trigger a sync. Now it does. :tada:

The [`all` event](https://github.com/paulmillr/chokidar#methods--events) includes `change, add, addDir, unlink, unlinkDir`.

Note that the `ignoreInitial` chokidar.watch option is needed to avoid
spurious `add` events when initially traversing the directory hierarchy.