### PR TITLE
Debounce/settle rsync, umount /Users, sync clock.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "b2d-sync",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "continous syncing of host folder to boot2docker VM via rsync",
   "main": "watch.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "continous syncing of host folder to boot2docker VM via rsync",
   "main": "watch.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jshint *.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "continous syncing of host folder to boot2docker VM via rsync",
   "main": "watch.js",
   "scripts": {
-    "test": "jshint *.js"
+      "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "homepage": "https://github.com/jkingyens/b2d-sync",
   "dependencies": {
     "async": "^0.9.0",
-    "chokidar": "^0.12.6",
+    "async-debounce": "0.0.0",
+    "chokidar": "^1.0.5",
     "nconf": "^0.7.1",
     "osenv": "^0.1.0"
   }

--- a/watch.js
+++ b/watch.js
@@ -52,6 +52,12 @@ function rsync (cb) {
   });
 }
 
+function umount (cb) {
+  cp.exec('boot2docker ssh "sudo umount /Users || /bin/true"', function() {
+    cb();
+  });
+}
+
 function mkdirp (cb) {
   cp.exec('boot2docker ssh "sudo mkdir -p ' + nconf.get('targetPath') + ' && sudo chown -R docker:staff ' + nconf.get('targetPath') + '"', function() {
     cb();


### PR DESCRIPTION
I added debouncing of rsync and also wait until fs events settle down before syncing.  This helps rsync behavior when doing things like switching branches, where a lot of files may change.

I also added automatic umount of `/Users` and syncing of the clock via ntp, since I've observed problems with clock drift in certain sleep/wake conditions.

Bumped version to .5 in case you want to npm publish.
